### PR TITLE
small fix to compile under g++ 4.8

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,11 +4,11 @@
 
 VERSION=0.4
 
+CC=g++
 CXX=g++
 #CXXFLAGS=-g -pedantic -Wall
 CXXFLAGS=-O -Wall
 CPPFLAGS=-DVERSION=\"V$(VERSION)\"
-LDFLAGS=-lstdc++
 
 CMDS = d64dump biosdump cformat ctools
 

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -259,7 +259,7 @@ cpm_filename(const char filename[])
 	char *s, *t, *dot;
 
 	// take basename
-	t = strrchr(filename, '/');
+	t = strrchr((char *) filename, '/');
 	if (t != NULL)
 		filename = t + 1;
 	s = strdup(filename);


### PR DESCRIPTION
This fix is needed to compile ctools under g++ 4.8.2
