### PR TITLE
Fixed clang 16

### DIFF
--- a/src/tools.cc
+++ b/src/tools.cc
@@ -259,7 +259,7 @@ cpm_filename(const char filename[])
 	char *s, *t, *dot;
 
 	// take basename
-	t = strrchr((char *) filename, '/');
+	t = (char *) strrchr((char *) filename, '/');
 	if (t != NULL)
 		filename = t + 1;
 	s = strdup(filename);


### PR DESCRIPTION
g++ -O -Wall -DVERSION=\"V0.4\"  -c -o tools.o tools.cc tools.cc:262:6: error: assigning to 'char *' from 'const char *' discards qualifiers
  262 |         t = strrchr(filename, '/');
      |             ^~~~~~~~~~~~~~~~~~~~~~
1 error generated.